### PR TITLE
Fix for quarkus 2.12+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>2.9.2.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.13.0.Final</quarkus.platform.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
   </properties>
   <dependencyManagement>

--- a/src/main/java/org/acme/UploadResource.java
+++ b/src/main/java/org/acme/UploadResource.java
@@ -58,20 +58,13 @@ public class UploadResource {
 
     // Class that will define the OpenAPI schema for the binary type input (upload)
     @Schema(type = SchemaType.STRING, format = "binary")
-    public interface UploadItemSchema {
-    }
-
-    // Class that will be used to define the request body, and with that
-    // it will allow uploading of "N" files
-    public class UploadFormSchema {
-        public List<UploadItemSchema> files;
-    }
+    public interface UploadItemSchema {}
 
     // We instruct OpenAPI to use the schema provided by the 'UploadFormSchema'
     // class implementation and thus define a valid OpenAPI schema for the Swagger
     // UI
-    @Schema(implementation = UploadFormSchema.class)
     public static class MultipartBody {
+        @Schema(implementation = UploadItemSchema[].class)
         @RestForm("files")
         public List<FileUpload> files;
     }


### PR DESCRIPTION
I tried your project, which work, but then it did not work in mine, which uses a more recent Quarkus version. I have raised the issue with Quarkus here; https://github.com/quarkusio/quarkus/issues/28231

Problem arised when quarkus updated smallrye-openapi to 2.1.23 to support resteasy-reactive

I have applied the fix and updated quarkus in your project in case anoter person gets the issue like I did.